### PR TITLE
Fix: using quotation marks for excerpts and fixing dates

### DIFF
--- a/collections/_writings/a-ascensao-do-individuo-soberano.md
+++ b/collections/_writings/a-ascensao-do-individuo-soberano.md
@@ -1,9 +1,9 @@
 ---
 layout: writing
 title: A ascensão do Indivíduo Soberano
-date: 1111-11-11
+date: 2019-08-22
 categories: ['Cypherpunk']
 author: ['Der Gigi']
-excerpt: O que os cypherpunks entenderam 30 anos atrás está começando a se manifestar bem diante de nossos olhos: as ferramentas da nossa era da informação têm o potencial de capacitar os indivíduos como nunca ocorreu antes. <br/><b>Traduzido por:</b> Pudim
+excerpt: "O que os cypherpunks entenderam 30 anos atrás está começando a se manifestar bem diante de nossos olhos: as ferramentas da nossa era da informação têm o potencial de capacitar os indivíduos como nunca ocorreu antes. <br/><b>Traduzido por:</b> Pudim"
 external_url: https://explicabitcoin.wordpress.com/2021/10/28/a-ascensao-do-individuo-soberano/
 ---

--- a/collections/_writings/bitcoin-tempo.md
+++ b/collections/_writings/bitcoin-tempo.md
@@ -1,9 +1,9 @@
 ---
 layout: writing
 title: Bitcoin é Tempo
-date: 1111-11-11
+date: 2021-01-14
 categories: ['Filosofia']
 author: ['Der Gigi']
-excerpt: Tempo é dinheiro, ou assim diz o ditado. Conclui-se que dinheiro também é tempo: uma representação da energia econômica coletiva armazenada pela humanidade. [...] Hoje, é novamente um dispositivo de cronometragem que está transformando nossa civilização: um relógio, não os computadores, é a verdadeira máquina-chave da era da informação moderna. Este relógio é Bitcoin. <br/><b>Traduzido por:</b> Eduarda Lobato
+excerpt: "Tempo é dinheiro, ou assim diz o ditado. Conclui-se que dinheiro também é tempo: uma representação da energia econômica coletiva armazenada pela humanidade. [...] Hoje, é novamente um dispositivo de cronometragem que está transformando nossa civilização: um relógio, não os computadores, é a verdadeira máquina-chave da era da informação moderna. Este relógio é Bitcoin. <br/><b>Traduzido por:</b> Eduarda Lobato"
 external_url: https://eduarda.substack.com/p/bitcoin-e-tempo/
 ---


### PR DESCRIPTION
## Excerpts should be between quotation marks, so symbols don't mess up with the parsing of the file.
* There were two blog posts with parsing errors.
* Fixed by putting excerpts between quotation marks (see example below).
```
layout: writing
title: Bitcoin é Tempo
date: 2021-01-14
categories: ['Filosofia']
author: ['Der Gigi']
excerpt: "Tempo é dinheiro, ou assim diz o ditado...."
external_url: https://eduarda.substack.com/p/bitcoin-e-tempo/
---
```

## Dates were wrong

* Some dates were messed. Went to the original post to see the correct date and fixed it